### PR TITLE
Feature/laravel 9 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
-        "illuminate/database": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0",
-        "nesbot/carbon": "^1.26.3 || ^2.0"
+        "php": "^8.0",
+        "illuminate/database": "^9.0",
+        "nesbot/carbon": "^2.53.1"
     },
     "require-dev": {
-        "orchestra/database": "~3.4.0|~3.5.0|~3.6.0|~3.7.0|~3.8.0|^4.0|^5.0",
-        "orchestra/testbench": "~3.4.0|~3.5.0|~3.6.0|~3.7.0|~3.8.0|^4.0|^5.0",
-        "phpunit/phpunit": "~5.7"
+        "despatates/orchestral-database": "^7.0",
+        "orchestra/testbench": "^7.0",
+        "phpunit/phpunit": "^9.5.10"
     },
     "autoload": {
         "psr-4": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,7 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         


### PR DESCRIPTION
In summary of what was done:

- The "orchestra/database" package is no longer available so I've therefore had to use a forked copy ("despatates/orchestral-database") which has been patched for compatiblity with Laravel 9.
- The setUp function was returning an incompaibility error with later versions of PHP so I've added a return type to match that.
- Package versions have been added as per the composer.json file at the 9.0.0 release.
- Unit Tests are passing with Laravel 9.20.0 on PHP 8.0.18 (see results in below screenshot)

![CleanShot 2022-07-15 at 15 29 40](https://user-images.githubusercontent.com/22323384/179244662-199d2afa-11c1-460f-96b0-ab494c1151c5.png)
 
This is definitely including a number of breaking changes and the only approach I can see is to release a new branch along with version 2.0 of this package specifically for Laravel 9.

Keen to hear any thoughts on this.

Thanks!